### PR TITLE
Improve support for different engines

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,13 @@ the log file and collect the statistics.
 from texoutparse import LatexLogParser
 
 parser = LatexLogParser()
+
+# If using a unicode-supporting engine, e.g. XeTeX or LuaTeX/LuaHBTeX
 with open('sample.log') as f:
+    parser.process(f)
+
+# If using an 8-bit engine, e.g. TeX or pdfTeX
+with open('sample.log', encoding='latin-1') as f:
     parser.process(f)
 ```
 The `parser` object contains lists of errors, warnings, and bad boxes, each described by an 


### PR DESCRIPTION
* Parse engine information

* Display a warning when attempting to read a TeX/pdfTeX log as utf8
  This one bit me personally and is also the subject of
  https://github.com/inakleinbottle/texoutparse/issues/1

* Parse messages from engines other than pdfTeX
  Note: not sure if such messages are possible but it seemed better than
  to support only pdfTeX